### PR TITLE
Feat: move panresponder to higher view

### DIFF
--- a/src/HuePicker.js
+++ b/src/HuePicker.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import {
   Animated,
   View,
-  TouchableWithoutFeedback,
   ViewPropTypes,
   PanResponder,
   StyleSheet,

--- a/src/HuePicker.js
+++ b/src/HuePicker.js
@@ -131,7 +131,7 @@ export default class HuePicker extends Component {
       borderRadius,
     } = this.props;
     return (
-      <View style={this.getContainerStyle()}>
+      <View style={this.getContainerStyle()} {...this.panResponder.panHandlers}>
         <LinearGradient
           colors={hueColors}
           style={{
@@ -141,7 +141,6 @@ export default class HuePicker extends Component {
           <View style={{
             width: barWidth, height: barHeight,
           }}
-          {...this.panResponder.panHandlers}
           />
         </LinearGradient>
         <Animated.View

--- a/src/HuePicker.js
+++ b/src/HuePicker.js
@@ -44,7 +44,7 @@ export default class HuePicker extends Component {
       },
       onPanResponderTerminationRequest: () => true,
       onPanResponderRelease: (evt, gestureState) => {
-        this.firePressEvent(evt);
+        this.fireReleaseEvent(evt);
         this.fireDragEvent('onDragEnd', gestureState);
       },
       onPanResponderTerminate: (evt, gestureState) => {
@@ -112,7 +112,7 @@ export default class HuePicker extends Component {
     }
   }
 
-  firePressEvent = (event) => {
+  fireReleaseEvent = (event) => {
     const { onPress } = this.props;
     if (onPress) {
       onPress({
@@ -132,20 +132,18 @@ export default class HuePicker extends Component {
     } = this.props;
     return (
       <View style={this.getContainerStyle()}>
-        <TouchableWithoutFeedback>
-          <LinearGradient
-            colors={hueColors}
-            style={{
-              borderRadius,
-            }}
-          >
-            <View style={{
-              width: barWidth, height: barHeight,
-            }}
-            {...this.panResponder.panHandlers}
-            />
-          </LinearGradient>
-        </TouchableWithoutFeedback>
+        <LinearGradient
+          colors={hueColors}
+          style={{
+            borderRadius,
+          }}
+        >
+          <View style={{
+            width: barWidth, height: barHeight,
+          }}
+          {...this.panResponder.panHandlers}
+          />
+        </LinearGradient>
         <Animated.View
           pointerEvents="none"
           style={[

--- a/src/SaturationValuePicker.js
+++ b/src/SaturationValuePicker.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import {
   View,
-  TouchableWithoutFeedback,
   ViewPropTypes,
   PanResponder,
   StyleSheet,

--- a/src/SaturationValuePicker.js
+++ b/src/SaturationValuePicker.js
@@ -14,18 +14,18 @@ import normalizeValue from './utils';
 export default class SaturationValuePicker extends Component {
   constructor(props) {
     super(props);
-    this.firePressEvent = this.firePressEvent.bind(this);
     this.panResponder = PanResponder.create({
       onStartShouldSetPanResponder: () => true,
       onStartShouldSetPanResponderCapture: () => true,
       onMoveShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponderCapture: () => true,
       onPanResponderGrant: (evt, gestureState) => {
-        const { saturation, value } = this.props;
-        this.dragStartValue = {
-          saturation,
-          value,
-        };
+        this.dragStartValue = this.computeSatValPress({
+          nativeEvent: {
+            locationX: evt.nativeEvent.locationX,
+            locationY: evt.nativeEvent.locationY,
+          }
+        });
         this.fireDragEvent('onDragStart', gestureState);
       },
       onPanResponderMove: (evt, gestureState) => {
@@ -33,6 +33,7 @@ export default class SaturationValuePicker extends Component {
       },
       onPanResponderTerminationRequest: () => true,
       onPanResponderRelease: (evt, gestureState) => {
+        this.firePressEvent(evt);
         this.fireDragEvent('onDragEnd', gestureState);
       },
       onPanResponderTerminate: (evt, gestureState) => {
@@ -42,7 +43,7 @@ export default class SaturationValuePicker extends Component {
     });
   }
 
-  getCurrentColor() {
+  getCurrentColor = () => {
     const { hue, saturation, value } = this.props;
     return chroma.hsv(
       hue,
@@ -51,7 +52,7 @@ export default class SaturationValuePicker extends Component {
     ).hex();
   }
 
-  computeSatValDrag(gestureState) {
+  computeSatValDrag = (gestureState) => {
     const { dx, dy } = gestureState;
     const { size } = this.props;
     const { saturation, value } = this.dragStartValue;
@@ -63,7 +64,7 @@ export default class SaturationValuePicker extends Component {
     };
   }
 
-  computeSatValPress(event) {
+  computeSatValPress = (event) => {
     const { nativeEvent } = event;
     const { locationX, locationY } = nativeEvent;
     const { size } = this.props;
@@ -73,7 +74,7 @@ export default class SaturationValuePicker extends Component {
     };
   }
 
-  fireDragEvent(eventName, gestureState) {
+  fireDragEvent = (eventName, gestureState) => {
     const { [eventName]: event } = this.props;
     if (event) {
       event({
@@ -83,7 +84,7 @@ export default class SaturationValuePicker extends Component {
     }
   }
 
-  firePressEvent(event) {
+  fireReleaseEvent = (event) => {
     const { onPress } = this.props;
     if (onPress) {
       onPress({
@@ -114,7 +115,7 @@ export default class SaturationValuePicker extends Component {
           },
         ]}
       >
-        <TouchableWithoutFeedback onPress={this.firePressEvent}>
+        <TouchableWithoutFeedback>
           <LinearGradient
             style={{
               borderRadius,
@@ -137,12 +138,13 @@ export default class SaturationValuePicker extends Component {
                   height: size,
                   width: size,
                 }}
+                {...this.panResponder.panHandlers}
               />
             </LinearGradient>
           </LinearGradient>
         </TouchableWithoutFeedback>
         <View
-          {...this.panResponder.panHandlers}
+           pointerEvents="none"
           style={[
             styles.slider,
             {

--- a/src/SaturationValuePicker.js
+++ b/src/SaturationValuePicker.js
@@ -114,6 +114,7 @@ export default class SaturationValuePicker extends Component {
             width: size + sliderSize,
           },
         ]}
+        {...this.panResponder.panHandlers}
       >
         <LinearGradient
           style={{
@@ -137,7 +138,6 @@ export default class SaturationValuePicker extends Component {
                 height: size,
                 width: size,
               }}
-              {...this.panResponder.panHandlers}
             />
           </LinearGradient>
         </LinearGradient>

--- a/src/SaturationValuePicker.js
+++ b/src/SaturationValuePicker.js
@@ -33,7 +33,7 @@ export default class SaturationValuePicker extends Component {
       },
       onPanResponderTerminationRequest: () => true,
       onPanResponderRelease: (evt, gestureState) => {
-        this.firePressEvent(evt);
+        this.fireReleaseEvent(evt);
         this.fireDragEvent('onDragEnd', gestureState);
       },
       onPanResponderTerminate: (evt, gestureState) => {
@@ -115,34 +115,32 @@ export default class SaturationValuePicker extends Component {
           },
         ]}
       >
-        <TouchableWithoutFeedback>
+        <LinearGradient
+          style={{
+            borderRadius,
+          }}
+          colors={[
+            '#fff',
+            chroma.hsl(hue, 1, 0.5).hex(),
+          ]}
+          start={[0, 0.5]}
+          end={[1, 0.5]}
+        >
           <LinearGradient
-            style={{
-              borderRadius,
-            }}
             colors={[
-              '#fff',
-              chroma.hsl(hue, 1, 0.5).hex(),
+              'rgba(0, 0, 0, 0)',
+              '#000',
             ]}
-            start={[0, 0.5]}
-            end={[1, 0.5]}
           >
-            <LinearGradient
-              colors={[
-                'rgba(0, 0, 0, 0)',
-                '#000',
-              ]}
-            >
-              <View
-                style={{
-                  height: size,
-                  width: size,
-                }}
-                {...this.panResponder.panHandlers}
-              />
-            </LinearGradient>
+            <View
+              style={{
+                height: size,
+                width: size,
+              }}
+              {...this.panResponder.panHandlers}
+            />
           </LinearGradient>
-        </TouchableWithoutFeedback>
+        </LinearGradient>
         <View
            pointerEvents="none"
           style={[


### PR DESCRIPTION
Moving panresponder in order to get touch events from the whole gradient zones instead of just the slider dots.

Also converted to arrow functions to avoid having to bind `this`